### PR TITLE
Add HTTP Strict Transport Security header

### DIFF
--- a/ocaml/libs/http-lib/http.ml
+++ b/ocaml/libs/http-lib/http.ml
@@ -128,6 +128,8 @@ module Hdr = struct
   let location = "location"
 
   let traceparent = "traceparent"
+
+  let hsts = "strict-transport-security"
 end
 
 let output_http fd headers =

--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -233,6 +233,9 @@ module Hdr : sig
   val location : string
 
   val traceparent : string
+
+  val hsts : string
+  (** Header used for HTTP Strict Transport Security *)
 end
 
 val output_http : Unix.file_descr -> string list -> unit

--- a/ocaml/libs/http-lib/http_svr.mli
+++ b/ocaml/libs/http-lib/http_svr.mli
@@ -120,7 +120,11 @@ val response_method_not_implemented :
 val response_redirect : ?req:Http.Request.t -> Unix.file_descr -> string -> unit
 
 val response_file :
-  ?mime_content_type:string -> Unix.file_descr -> string -> unit
+     ?mime_content_type:string
+  -> hsts_time:int
+  -> Unix.file_descr
+  -> string
+  -> unit
 
 val respond_to_options : Http.Request.t -> Unix.file_descr -> unit
 

--- a/ocaml/xapi/fileserver.ml
+++ b/ocaml/xapi/fileserver.ml
@@ -76,7 +76,8 @@ let response_file s file_path =
     let ext = Option.map String.lowercase_ascii (get_extension file_path) in
     Option.fold ~none:application_octet_stream ~some:mime_of_extension ext
   in
-  Http_svr.response_file ~mime_content_type s file_path
+  let hsts_time = !Xapi_globs.hsts_max_age in
+  Http_svr.response_file ~mime_content_type ~hsts_time s file_path
 
 let is_external_http req s =
   (not (Context.is_unix_socket s)) && Context._client_of_rq req = None

--- a/ocaml/xapi/system_status.ml
+++ b/ocaml/xapi/system_status.ml
@@ -92,10 +92,12 @@ let send_via_cp __context s entries output =
   let () = debug "running %s" cmd in
   try
     let filename = String.rtrim (Helpers.get_process_output cmd) in
+    let hsts_time = !Xapi_globs.hsts_max_age in
     finally
       (fun () ->
         debug "bugball path: %s" filename ;
-        Http_svr.response_file ~mime_content_type:content_type s filename
+        Http_svr.response_file ~mime_content_type:content_type ~hsts_time s
+          filename
       )
       (fun () ->
         Helpers.log_exn_continue "deleting xen-bugtool output" Unix.unlink

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -820,6 +820,8 @@ let sm_dir = ref "/opt/xensource/sm"
 
 let web_dir = ref "/opt/xensource/www"
 
+let hsts_max_age = ref (-1)
+
 let website_https_only = ref true
 
 let migration_https_only = ref true
@@ -1372,6 +1374,12 @@ let other_options =
     , Arg.Set_float winbind_ldap_query_subject_timeout
     , (fun () -> string_of_float !winbind_ldap_query_subject_timeout)
     , "Timeout to perform ldap query for subject information"
+    )
+  ; ( "hsts_max_age"
+    , Arg.Set_int hsts_max_age
+    , (fun () -> string_of_int !hsts_max_age)
+    , "number of seconds after the reception of the STS header field, during \
+       which the UA as a known HSTS Host (default = -1 means HSTS is disabled)"
     )
   ; ( "website-https-only"
     , Arg.Set website_https_only

--- a/ocaml/xapi/xapi_vncsnapshot.ml
+++ b/ocaml/xapi/xapi_vncsnapshot.ml
@@ -46,8 +46,9 @@ let vncsnapshot_handler (req : Request.t) s _ =
                 ; tmp
                 ]
             in
+            let hsts_time = !Xapi_globs.hsts_max_age in
             waitpid_fail_if_bad_exit pid ;
-            Http_svr.response_file s tmp
+            Http_svr.response_file ~hsts_time s tmp
           )
           (fun () -> try Unix.unlink tmp with _ -> ())
       with e ->


### PR DESCRIPTION
This header informs the browser that it should use HTTPS. The max-age is set to 2 years.